### PR TITLE
fix: normalize custom request methods to uppercase

### DIFF
--- a/source/utils/normalize.ts
+++ b/source/utils/normalize.ts
@@ -1,9 +1,7 @@
-import {requestMethods} from '../core/constants.js';
 import type {RetryOptions} from '../types/retry.js';
-import type {HttpMethod, RequestHttpMethod} from '../types/options.js';
+import type {HttpMethod} from '../types/options.js';
 
-export const normalizeRequestMethod = (input: string): string =>
-	requestMethods.includes(input as RequestHttpMethod) ? input.toUpperCase() : input;
+export const normalizeRequestMethod = (input: string): string => input.toUpperCase();
 
 const retryMethods: HttpMethod[] = ['get', 'put', 'head', 'delete', 'options', 'trace'];
 

--- a/test/methods.ts
+++ b/test/methods.ts
@@ -43,22 +43,21 @@ test('method defaults to "GET"', async t => {
 	);
 });
 
-test.failing('custom method remains identical', async t => {
+test('custom method is normalized to uppercase', async t => {
 	const server = await createHttpTestServer(t);
 	server.all('/', (_request, response) => {
 		response.end();
 	});
 
-	t.plan(1);
+	t.plan(2);
 
 	await t.notThrowsAsync(
-		// TODO: Is it correct for this to throw 400 status code?
 		ky(server.url, {
 			method: 'report',
 			hooks: {
 				beforeRequest: [
 					({options}) => {
-						t.is(options.method, 'report');
+						t.is(options.method, 'REPORT');
 					},
 				],
 			},


### PR DESCRIPTION
## Summary
- normalize all request methods to uppercase before Request construction
- convert the existing custom-method failing test into a passing assertion for uppercase normalization
- ensure lowercase custom methods like `report` are sent as `REPORT` in Node.js

## Why
Closes #4. Lowercase custom methods can be rejected with HTTP 400 by Node.js/undici before the request reaches the target server.

## Validation
- `npm run build`
- `npx ava test/methods.ts`
- executed inside docker container (`docker compose exec -T ky-dev ...`)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the issue where lowercase custom HTTP methods were rejected with HTTP 400 errors by Node.js/undici. The fix simplifies `normalizeRequestMethod` to unconditionally uppercase all methods instead of only standard ones.

**Key changes:**
- Removed conditional logic that only uppercased standard HTTP methods
- All custom methods (like `'report'`) are now normalized to uppercase (`'REPORT'`)
- Updated the failing test to a passing assertion verifying the uppercase normalization
- Aligns with HTTP standards where method tokens are case-sensitive and conventionally uppercase
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Simple bug fix with clear intent, well-tested implementation, and no edge cases or breaking changes that would affect legitimate use cases
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| source/utils/normalize.ts | Simplified `normalizeRequestMethod` to unconditionally uppercase all HTTP methods, fixing Node.js/undici rejection of lowercase custom methods |
| test/methods.ts | Updated test from `test.failing` to passing test that verifies custom method `'report'` is normalized to `'REPORT'` |

</details>


</details>


<sub>Last reviewed commit: 470891c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->