### PR TITLE
docs(types): record TS blocker for constrained json generic

### DIFF
--- a/source/types/ResponsePromise.ts
+++ b/source/types/ResponsePromise.ts
@@ -18,8 +18,9 @@ export type ResponsePromise<T = unknown> = {
 	*/
 	bytes: () => Promise<Uint8Array>;
 
-	// TODO: Use `json<T extends JSONValue>(): Promise<T>;` when it's fixed in TS.
-	// See https://github.com/microsoft/TypeScript/issues/15300 and https://github.com/sindresorhus/ky/pull/80
+	// TODO: Use `json<T extends JSONValue>(): Promise<T>;` when TypeScript's fetch typing allows it.
+	// Checked on TypeScript 5.9.3 (2026-03-04): still blocked, so keep this generic unconstrained for now.
+	// Tracking: https://github.com/microsoft/TypeScript/issues/15300 and https://github.com/sindresorhus/ky/pull/80
 	json: {
 		/**
 		Get the response body as JSON.


### PR DESCRIPTION
## Summary
- clarify the `ResponsePromise.json()` TODO to explicitly reference the current TypeScript blocker
- record the latest verification point (TypeScript 5.9.3, checked 2026-03-04)
- keep behavior unchanged while documenting why adoption is deferred

## Issue
Closes #2.

## Validation
- `docker compose exec -T ky-dev bash -lc 'npm run build'`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updated the TODO comment for the `json()` method to provide clearer context on why the generic type constraint hasn't been adopted yet.

- Clarified that TypeScript's fetch typing is the blocker (not just "fixed in TS")
- Added verification checkpoint: TypeScript 5.9.3 (2026-03-04)
- Explained the decision to keep the generic unconstrained for now
- Changed "See" to "Tracking" for the referenced issues
</details>


<h3>Confidence Score: 5/5</h3>

- This PR is completely safe to merge - documentation-only change with no runtime impact
- Pure documentation improvement that adds clarity and context without changing any code behavior. The comment update is well-written and provides valuable historical context for future maintainers.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| source/types/ResponsePromise.ts | Enhanced TODO comment with explicit TypeScript version verification and clearer blocker explanation |

</details>


</details>


<sub>Last reviewed commit: cc6d913</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->