### PR TITLE
refactor(types): remove any from deepMerge helper

### DIFF
--- a/source/utils/merge.ts
+++ b/source/utils/merge.ts
@@ -163,6 +163,12 @@ const mergeRecordEntry = (
 		return resultRecord;
 	}
 
+	// Skip hooks/headers - let mergeSpecialOptions handle them exclusively
+	if (key === 'hooks' || key === 'headers') {
+		return resultRecord;
+	}
+
+	// Deep merge objects that already exist in the result
 	if (isObject(value) && key in resultRecord) {
 		const existingValue = resultRecord[key] as Record<string, unknown>;
 		value = deepMerge<Record<string, unknown>>(existingValue, value as Record<string, unknown>);
@@ -235,10 +241,18 @@ export const deepMerge = <T>(...sources: Array<Partial<T> | undefined>): T => {
 		returnValue = resultRecord;
 	}
 
+	// Handle array return value - apply special options without converting to object
 	if (Array.isArray(returnValue)) {
+		const arrayRecord = returnValue as unknown as Record<string, unknown>;
+		if (state.searchParameters !== undefined) {
+			arrayRecord['searchParams'] = state.searchParameters;
+		}
+
+		mergeSignalValues(arrayRecord, state.signals);
 		return returnValue as T;
 	}
 
+	// Convert to record to apply special options
 	const mergedRecord = asMergeRecord(returnValue);
 
 	if (state.searchParameters !== undefined) {

--- a/test/main.ts
+++ b/test/main.ts
@@ -841,7 +841,12 @@ test('deepMerge preserves array indices when merging with object', async t => {
 
 	// When merging an array first, then an object, the array indices should be preserved
 	const result = deepMerge([1, 2, 3], {foo: 'bar'});
-	t.deepEqual(result, {0: 1, 1: 2, 2: 3, foo: 'bar'}, 'array indices should be preserved when merging with object');
+	t.deepEqual(result, {
+		0: 1,
+		1: 2,
+		2: 3,
+		foo: 'bar',
+	}, 'array indices should be preserved when merging with object');
 });
 
 test('throwHttpErrors option', async t => {


### PR DESCRIPTION
## Summary
- remove `any` usage from `source/utils/merge.ts` by introducing typed merge intermediates
- type `appendSearchParameters` using `SearchParamsOption`
- preserve existing deep-merge runtime behavior while improving type-safety in hooks/headers/searchParams merging

## Validation
- `npm run build`
- `npx ava test/hooks.ts test/stream.ts`

Fixes #1

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refactors `source/utils/merge.ts` to eliminate all `any` usage from the `deepMerge` utility by introducing typed intermediate types (`MergeTarget`, `MergeState`) and extracting logic into focused helpers (`asMergeRecord`, `mergeRecordEntry`, `mergeSpecialOptions`, `mergeSignalValues`, `mergeContextValue`, `mergeSearchParameters`). It also properly types `appendSearchParameters` using the existing `SearchParamsOption` type. The runtime behaviour is largely preserved and the issues raised in previous review threads (array-index spread, redundant hooks/headers processing, lost `searchParams` when final source is an array) have all been addressed.

**Key changes:**
- `appendSearchParameters` is now split into `appendSearchParameterInput` (per-input helper) and a typed outer wrapper, removing `any` parameters
- `deepMerge` loop body is decomposed into `mergeRecordEntry` (immutable per-key logic) and `mergeSpecialOptions` (in-place hooks/headers accumulation), making the flow easier to follow
- `asMergeRecord` preserves array-index entries via `{...array}` spread, fixing a previously-noted regression
- A post-loop block applies accumulated `searchParams` and signals even when `returnValue` is an array, addressing another prior concern
- A new test validates array-index preservation when merging an array source followed by an object source
</details>

<h3>Confidence Score: 4/5</h3>

- Safe to merge; the refactoring is logically sound and addresses the issues raised in prior review threads, with only minor style and documentation gaps remaining.
- The core logic is preserved correctly across all edge cases (array sources, signal merging, searchParams accumulation, context shallow-merge). The `any` removal is thorough and the new typed helpers are clear. Two minor concerns lower the score slightly: the inconsistent mutation style in `mergeSpecialOptions` relative to the rest of the helpers, and the undocumented asymmetric reset behaviour for `context` vs. `searchParams`. Neither constitutes a runtime bug for current call-sites, but they could confuse future contributors.
- Pay close attention to `source/utils/merge.ts` around `mergeContextValue` (lines 119–132) and `mergeSpecialOptions` (lines 180–190) for the semantic and style concerns noted.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| source/utils/merge.ts | Core refactor removing `any` from `deepMerge` — introduces well-typed helpers (`MergeState`, `MergeTarget`, `asMergeRecord`, `mergeRecordEntry`, `mergeSpecialOptions`, `mergeSignalValues`). Logic is correct and addresses issues raised in prior review threads; minor concerns around the inconsistent mutation style in `mergeSpecialOptions` vs. the immutable pattern used elsewhere, and undocumented asymmetric reset semantics for `context` vs `searchParams`. |
| test/main.ts | Adds one regression test for `deepMerge([array], {object})` array-index preservation. Test is correctly structured but only covers one direction of the array/object merge; the reverse direction (object then array) is not tested, leaving undocumented the "object is discarded" semantics. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[deepMerge sources] --> B[Init returnValue and MergeState]
    B --> C{For each source}
    C -->|Array| D[Concat into returnValue array]
    D --> C
    C -->|Plain object| E[asMergeRecord converts returnValue]
    E --> F[Loop: mergeRecordEntry per key]
    F --> G{Key type?}
    G -->|signal| H[Append to state.signals]
    G -->|context| I[mergeContextValue shallow merge]
    G -->|searchParams| J[mergeSearchParameters accumulate]
    G -->|hooks or headers| K[Skip - delegated below]
    G -->|other| L[Deep merge or assign]
    H & I & J & K & L --> M[mergeSpecialOptions mutates resultRecord for hooks and headers]
    M --> N[returnValue = resultRecord]
    N --> C
    C -->|All sources done| O{returnValue is array?}
    O -->|Yes| P[Apply searchParameters and signals as array properties then return]
    O -->|No| Q[Apply searchParameters and mergeSignalValues then return record]
```
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asource%2Futils%2Fmerge.ts%3A180-190%0A**Inconsistent%20mutation%20vs.%20immutable%20pattern**%0A%0A%60mergeSpecialOptions%60%20mutates%20%60resultRecord%60%20directly%20%28e.g.%2C%20%60resultRecord%5B'hooks'%5D%20%3D%20state.hooks%60%29%2C%20while%20%60mergeRecordEntry%60%20follows%20a%20purely%20immutable%20pattern%20and%20always%20returns%20a%20new%20spread%20object.%20This%20inconsistency%20is%20subtle%20but%20could%20cause%20confusion%3A%20a%20reader%20might%20assume%20%60resultRecord%60%20after%20the%20%60mergeRecordEntry%60%20loop%20is%20safe%20to%20re-use%20or%20discard%2C%20not%20realising%20it%20is%20further%20mutated%20synchronously%20by%20%60mergeSpecialOptions%60%20before%20%60returnValue%60%20is%20updated.%0A%0AConsider%20either%3A%0A1.%20Making%20%60mergeSpecialOptions%60%20return%20a%20new%20record%20%28consistent%20with%20%60mergeRecordEntry%60%29%2C%20or%0A2.%20Adding%20a%20brief%20comment%20next%20to%20the%20call-site%20noting%20the%20in-place%20mutation%3A%0A%0A%60%60%60typescript%0A%2F%2F%20mergeSpecialOptions%20mutates%20resultRecord%20in%20place%3B%20returnValue%20must%20be%0A%2F%2F%20updated%20only%20after%20this%20call.%0AmergeSpecialOptions%28resultRecord%2C%20sourceRecord%2C%20state%29%3B%0AreturnValue%20%3D%20resultRecord%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Fmain.ts%3A838-850%0A**Test%20only%20covers%20one%20direction%20of%20array%2Fobject%20merge**%0A%0AThe%20new%20test%20only%20exercises%20%60deepMerge%28%5B1%2C%202%2C%203%5D%2C%20%7Bfoo%3A%20'bar'%7D%29%60%20%28array-first%29.%20The%20previously%20discussed%20behavioural%20regression%20concerned%20both%20this%20case%20and%20its%20inverse.%20Consider%20adding%20the%20reverse%20direction%20to%20give%20complete%20coverage%3A%0A%0A%60%60%60typescript%0A%2F%2F%20Array%20after%20object%20-%20array%20should%20become%20the%20sole%20return%20value%20%28object%20discarded%29%0Aconst%20result2%20%3D%20deepMerge%28%7Bfoo%3A%20'bar'%7D%2C%20%5B1%2C%202%2C%203%5D%29%3B%0At.deepEqual%28result2%2C%20%5B1%2C%202%2C%203%5D%2C%20'object%20should%20be%20discarded%20when%20a%20later%20source%20is%20an%20array'%29%3B%0A%60%60%60%0A%0AThis%20documents%20the%20known%20%22object%20discarded%22%20semantics%20explicitly%20so%20future%20contributors%20are%20not%20surprised.%0A%0A%23%23%23%20Issue%203%20of%203%0Asource%2Futils%2Fmerge.ts%3A119-132%0A**Asymmetric%20reset%20semantics%20between%20%60context%60%20and%20%60searchParams%60**%0A%0AWhen%20%60value%60%20is%20%60undefined%60%20or%20%60null%60%2C%20%60mergeContextValue%60%20actively%20**sets**%20%60context%60%20to%20%60%7B%7D%60%20in%20the%20result%20record.%20The%20analogous%20reset%20path%20for%20%60searchParams%60%20%28inside%20%60mergeSearchParameters%60%29%20instead%20removes%20the%20key%20entirely%20by%20returning%20%60undefined%60.%20The%20asymmetry%20means%3A%0A%0A-%20%60deepMerge%28%7Bcontext%3A%20%7Ba%3A%201%7D%7D%2C%20%7Bcontext%3A%20null%7D%29%60%20%E2%86%92%20result%20has%20%60context%60%20key%20present%2C%20set%20to%20%60%7B%7D%60%0A-%20%60deepMerge%28%7BsearchParams%3A%20'q%3D1'%7D%2C%20%7BsearchParams%3A%20null%7D%29%60%20%E2%86%92%20result%20has%20no%20%60searchParams%60%20key%20at%20all%0A%0AWhile%20this%20matches%20the%20old%20code's%20behaviour%2C%20extracting%20the%20logic%20into%20%60mergeContextValue%60%20makes%20the%20semantic%20inconsistency%20more%20visible.%20If%20the%20intent%20is%20%22passing%20%60undefined%60%20or%20%60null%60%20clears%20context%20to%20an%20empty%20object%22%2C%20a%20short%20comment%20next%20to%20the%20ternary%20would%20prevent%20future%20readers%20from%20accidentally%20%22fixing%22%20it%20towards%20the%20%60searchParams%60%20pattern%3A%0A%0A&repo=vikasagarwal101%2Fky"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asource%2Futils%2Fmerge.ts%3A180-190%0A**Inconsistent%20mutation%20vs.%20immutable%20pattern**%0A%0A%60mergeSpecialOptions%60%20mutates%20%60resultRecord%60%20directly%20%28e.g.%2C%20%60resultRecord%5B'hooks'%5D%20%3D%20state.hooks%60%29%2C%20while%20%60mergeRecordEntry%60%20follows%20a%20purely%20immutable%20pattern%20and%20always%20returns%20a%20new%20spread%20object.%20This%20inconsistency%20is%20subtle%20but%20could%20cause%20confusion%3A%20a%20reader%20might%20assume%20%60resultRecord%60%20after%20the%20%60mergeRecordEntry%60%20loop%20is%20safe%20to%20re-use%20or%20discard%2C%20not%20realising%20it%20is%20further%20mutated%20synchronously%20by%20%60mergeSpecialOptions%60%20before%20%60returnValue%60%20is%20updated.%0A%0AConsider%20either%3A%0A1.%20Making%20%60mergeSpecialOptions%60%20return%20a%20new%20record%20%28consistent%20with%20%60mergeRecordEntry%60%29%2C%20or%0A2.%20Adding%20a%20brief%20comment%20next%20to%20the%20call-site%20noting%20the%20in-place%20mutation%3A%0A%0A%60%60%60typescript%0A%2F%2F%20mergeSpecialOptions%20mutates%20resultRecord%20in%20place%3B%20returnValue%20must%20be%0A%2F%2F%20updated%20only%20after%20this%20call.%0AmergeSpecialOptions%28resultRecord%2C%20sourceRecord%2C%20state%29%3B%0AreturnValue%20%3D%20resultRecord%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Atest%2Fmain.ts%3A838-850%0A**Test%20only%20covers%20one%20direction%20of%20array%2Fobject%20merge**%0A%0AThe%20new%20test%20only%20exercises%20%60deepMerge%28%5B1%2C%202%2C%203%5D%2C%20%7Bfoo%3A%20'bar'%7D%29%60%20%28array-first%29.%20The%20previously%20discussed%20behavioural%20regression%20concerned%20both%20this%20case%20and%20its%20inverse.%20Consider%20adding%20the%20reverse%20direction%20to%20give%20complete%20coverage%3A%0A%0A%60%60%60typescript%0A%2F%2F%20Array%20after%20object%20-%20array%20should%20become%20the%20sole%20return%20value%20%28object%20discarded%29%0Aconst%20result2%20%3D%20deepMerge%28%7Bfoo%3A%20'bar'%7D%2C%20%5B1%2C%202%2C%203%5D%29%3B%0At.deepEqual%28result2%2C%20%5B1%2C%202%2C%203%5D%2C%20'object%20should%20be%20discarded%20when%20a%20later%20source%20is%20an%20array'%29%3B%0A%60%60%60%0A%0AThis%20documents%20the%20known%20%22object%20discarded%22%20semantics%20explicitly%20so%20future%20contributors%20are%20not%20surprised.%0A%0A%23%23%23%20Issue%203%20of%203%0Asource%2Futils%2Fmerge.ts%3A119-132%0A**Asymmetric%20reset%20semantics%20between%20%60context%60%20and%20%60searchParams%60**%0A%0AWhen%20%60value%60%20is%20%60undefined%60%20or%20%60null%60%2C%20%60mergeContextValue%60%20actively%20**sets**%20%60context%60%20to%20%60%7B%7D%60%20in%20the%20result%20record.%20The%20analogous%20reset%20path%20for%20%60searchParams%60%20%28inside%20%60mergeSearchParameters%60%29%20instead%20removes%20the%20key%20entirely%20by%20returning%20%60undefined%60.%20The%20asymmetry%20means%3A%0A%0A-%20%60deepMerge%28%7Bcontext%3A%20%7Ba%3A%201%7D%7D%2C%20%7Bcontext%3A%20null%7D%29%60%20%E2%86%92%20result%20has%20%60context%60%20key%20present%2C%20set%20to%20%60%7B%7D%60%0A-%20%60deepMerge%28%7BsearchParams%3A%20'q%3D1'%7D%2C%20%7BsearchParams%3A%20null%7D%29%60%20%E2%86%92%20result%20has%20no%20%60searchParams%60%20key%20at%20all%0A%0AWhile%20this%20matches%20the%20old%20code's%20behaviour%2C%20extracting%20the%20logic%20into%20%60mergeContextValue%60%20makes%20the%20semantic%20inconsistency%20more%20visible.%20If%20the%20intent%20is%20%22passing%20%60undefined%60%20or%20%60null%60%20clears%20context%20to%20an%20empty%20object%22%2C%20a%20short%20comment%20next%20to%20the%20ternary%20would%20prevent%20future%20readers%20from%20accidentally%20%22fixing%22%20it%20towards%20the%20%60searchParams%60%20pattern%3A%0A%0A&repo=vikasagarwal101%2Fky"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<sub>Last reviewed commit: c7465f3</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->