### PR TITLE
fix(lint): resolve linting errors in test/type-guards.ts

### DIFF
--- a/test/type-guards.ts
+++ b/test/type-guards.ts
@@ -1,0 +1,102 @@
+import test from 'ava';
+import {
+	HTTPError, TimeoutError, ForceRetryError, isHTTPError, isTimeoutError, isForceRetryError, isKyError,
+} from '../source/index.js';
+
+// IsKyError tests
+
+test('isKyError returns true for HTTPError', t => {
+	// @ts-expect-error missing options
+	const error = new HTTPError(new Response(), new Request('https://example.com'));
+	t.true(isKyError(error));
+});
+
+test('isKyError returns true for TimeoutError', t => {
+	const error = new TimeoutError(new Request('https://example.com'));
+	t.true(isKyError(error));
+});
+
+test('isKyError returns true for ForceRetryError', t => {
+	const error = new ForceRetryError();
+	t.true(isKyError(error));
+});
+
+test('isKyError returns false for generic Error', t => {
+	const error = new Error('test');
+	t.false(isKyError(error));
+});
+
+test('isKyError returns false for non-Error values', t => {
+	t.false(isKyError(null));
+	t.false(isKyError(undefined));
+	t.false(isKyError('error'));
+	t.false(isKyError(123));
+	t.false(isKyError({}));
+});
+
+// IsHTTPError tests
+
+test('isHTTPError returns true for HTTPError instance', t => {
+	// @ts-expect-error missing options
+	const error = new HTTPError(new Response(), new Request('https://example.com'));
+	t.true(isHTTPError(error));
+});
+
+test('isHTTPError returns false for generic Error', t => {
+	const error = new Error('test');
+	t.false(isHTTPError(error));
+});
+
+test('isHTTPError cross-realm detection - object with name HTTPError', t => {
+	const fakeHTTPError = {name: 'HTTPError'};
+	t.true(isHTTPError(fakeHTTPError));
+});
+
+test('isHTTPError returns false for object with different name', t => {
+	const fakeError = {name: 'OtherError'};
+	t.false(isHTTPError(fakeError));
+});
+
+// IsTimeoutError tests
+
+test('isTimeoutError returns true for TimeoutError instance', t => {
+	const error = new TimeoutError(new Request('https://example.com'));
+	t.true(isTimeoutError(error));
+});
+
+test('isTimeoutError returns false for generic Error', t => {
+	const error = new Error('test');
+	t.false(isTimeoutError(error));
+});
+
+test('isTimeoutError cross-realm detection - object with name TimeoutError', t => {
+	const fakeTimeoutError = {name: 'TimeoutError'};
+	t.true(isTimeoutError(fakeTimeoutError));
+});
+
+test('isTimeoutError returns false for object with different name', t => {
+	const fakeError = {name: 'OtherError'};
+	t.false(isTimeoutError(fakeError));
+});
+
+// IsForceRetryError tests
+
+test('isForceRetryError returns true for ForceRetryError instance', t => {
+	const error = new ForceRetryError();
+	t.true(isForceRetryError(error));
+});
+
+test('isForceRetryError returns false for generic Error', t => {
+	const error = new Error('test');
+	t.false(isForceRetryError(error));
+});
+
+test('isForceRetryError cross-realm detection - object with name ForceRetryError', t => {
+	const fakeForceRetryError = {name: 'ForceRetryError'};
+	t.true(isForceRetryError(fakeForceRetryError));
+});
+
+test('isForceRetryError returns false for object with different name', t => {
+	const fakeError = {name: 'OtherError'};
+	t.false(isForceRetryError(fakeError));
+});


### PR DESCRIPTION
## Summary
Fixes linting errors in `test/type-guards.ts` to comply with the project's lint rules.

## Changes
- **object-curly-newline**: Added line breaks to the import statement
- **capitalized-comments**: Capitalized comment headers:
  - `// isKyError tests` → `// IsKyError tests`
  - `// isHTTPError tests` → `// IsHTTPError tests`
  - `// isTimeoutError tests` → `// IsTimeoutError tests`
  - `// isForceRetryError tests` → `// IsForceRetryError tests`

## Testing
- All existing tests pass
- Lint checks now pass for this file

## Related
Closes #17

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a new test file `test/type-guards.ts` providing comprehensive coverage for all four type guard functions exported by the library: `isKyError`, `isHTTPError`, `isTimeoutError`, and `isForceRetryError`. It also capitalizes inline comment section headers to satisfy the XO `capitalized-comments` lint rule and restructures the import for `object-curly-newline` compliance.

**Key observations:**
- Test assertions are logically correct — each test accurately reflects the behaviour of the corresponding guard implementations in `source/utils/type-guards.ts`
- Import formatting passes linting as expected
- Cross-realm detection tests (`{name: 'SomeError'}`) are present for `isHTTPError`, `isTimeoutError`, and `isForceRetryError`, but no equivalent tests exist for `isKyError`. Since `isKyError` delegates to those individual guards, `isKyError({name: 'HTTPError'})` would return `true` via delegation, and this implicit behaviour deserves explicit coverage for clarity
</details>

<h3>Confidence Score: 4/5</h3>

- Safe to merge — test logic is correct, no functional risks, and linting passes
- The test suite is well-structured and logically sound with correct assertions. The file creates no risk of breaking existing functionality and is self-contained. One non-blocking suggestion for enhanced test coverage (explicit cross-realm detection for isKyError) would improve test clarity but is not required for correctness.
- test/type-guards.ts — consider adding cross-realm detection tests for isKyError to match coverage of sibling guards

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Ftype-guards.ts%3A35%0AThe%20tests%20for%20%60isHTTPError%60%2C%20%60isTimeoutError%60%2C%20and%20%60isForceRetryError%60%20each%20include%20a%20cross-realm%20detection%20test%20%28e.g.%2C%20%60%7Bname%3A%20'HTTPError'%7D%60%29%2C%20but%20the%20%60isKyError%60%20test%20suite%20has%20no%20equivalent.%20Because%20%60isKyError%60%20delegates%20to%20those%20individual%20guards%2C%20%60isKyError%28%7Bname%3A%20'HTTPError'%7D%29%60%20would%20actually%20return%20%60true%60%20%E2%80%94%20this%20case%20is%20untested.%20Additionally%2C%20%60isKyError%28%7Bname%3A%20'KyError'%7D%29%60%20would%20return%20%60false%60%20%28no%20name-based%20check%20in%20the%20implementation%20for%20%60KyError%60%20itself%29%2C%20which%20is%20also%20worth%20asserting%20explicitly%20for%20documentation%20value.%0A%0AConsider%20adding%3A%0A%0A%60%60%60suggestion%0Atest%28'isKyError%20returns%20true%20for%20cross-realm%20HTTPError%20object'%2C%20t%20%3D%3E%20%7B%0A%09t.true%28isKyError%28%7Bname%3A%20'HTTPError'%7D%29%29%3B%0A%7D%29%3B%0A%0Atest%28'isKyError%20returns%20false%20for%20plain%20object%20with%20KyError%20name'%2C%20t%20%3D%3E%20%7B%0A%09t.false%28isKyError%28%7Bname%3A%20'KyError'%7D%29%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A&repo=vikasagarwal101%2Fky"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atest%2Ftype-guards.ts%3A35%0AThe%20tests%20for%20%60isHTTPError%60%2C%20%60isTimeoutError%60%2C%20and%20%60isForceRetryError%60%20each%20include%20a%20cross-realm%20detection%20test%20%28e.g.%2C%20%60%7Bname%3A%20'HTTPError'%7D%60%29%2C%20but%20the%20%60isKyError%60%20test%20suite%20has%20no%20equivalent.%20Because%20%60isKyError%60%20delegates%20to%20those%20individual%20guards%2C%20%60isKyError%28%7Bname%3A%20'HTTPError'%7D%29%60%20would%20actually%20return%20%60true%60%20%E2%80%94%20this%20case%20is%20untested.%20Additionally%2C%20%60isKyError%28%7Bname%3A%20'KyError'%7D%29%60%20would%20return%20%60false%60%20%28no%20name-based%20check%20in%20the%20implementation%20for%20%60KyError%60%20itself%29%2C%20which%20is%20also%20worth%20asserting%20explicitly%20for%20documentation%20value.%0A%0AConsider%20adding%3A%0A%0A%60%60%60suggestion%0Atest%28'isKyError%20returns%20true%20for%20cross-realm%20HTTPError%20object'%2C%20t%20%3D%3E%20%7B%0A%09t.true%28isKyError%28%7Bname%3A%20'HTTPError'%7D%29%29%3B%0A%7D%29%3B%0A%0Atest%28'isKyError%20returns%20false%20for%20plain%20object%20with%20KyError%20name'%2C%20t%20%3D%3E%20%7B%0A%09t.false%28isKyError%28%7Bname%3A%20'KyError'%7D%29%29%3B%0A%7D%29%3B%0A%60%60%60%0A%0A&repo=vikasagarwal101%2Fky"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<sub>Last reviewed commit: 4e12e0b</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->