### PR TITLE
refactor: extract createTextDecoder utility to utils/body.ts

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -12,7 +12,7 @@ import type {
 } from '../types/options.js';
 import {type ResponsePromise} from '../types/ResponsePromise.js';
 import type {StandardSchemaV1} from '../types/standard-schema.js';
-import {streamRequest, streamResponse} from '../utils/body.js';
+import {streamRequest, streamResponse, createTextDecoder} from '../utils/body.js';
 import {mergeHeaders, mergeHooks} from '../utils/merge.js';
 import {normalizeRequestMethod, normalizeRetryOptions} from '../utils/normalize.js';
 import {validateJsonWithSchema} from '../utils/schema.js';
@@ -36,17 +36,7 @@ import {
 const maxErrorResponseBodySize = 10 * 1024 * 1024;
 const prefixUrlRenamedErrorMessage = 'The `prefixUrl` option has been renamed `prefix` in v2 and enhanced to allow slashes in input. See also the new `baseUrl` option for improved flexibility with standard URL resolution: https://github.com/sindresorhus/ky#baseurl';
 
-const createTextDecoder = (contentType: string): TextDecoder => {
-	const match = /;\s*charset\s*=\s*(?:"([^"]+)"|([^;,\s]+))/i.exec(contentType);
-	const charset = match?.[1] ?? match?.[2];
-	if (charset) {
-		try {
-			return new TextDecoder(charset);
-		} catch {}
-	}
 
-	return new TextDecoder();
-};
 
 export class Ky {
 	static create(input: Input, options: Options): ResponsePromise {

--- a/source/utils/body.ts
+++ b/source/utils/body.ts
@@ -1,6 +1,25 @@
 import type {Options} from '../types/options.js';
 import {usualFormBoundarySize} from '../core/constants.js';
 
+/**
+ * Creates a TextDecoder instance with the charset extracted from the content-type header.
+ * Falls back to the default decoder if the charset is invalid or not specified.
+ *
+ * @param contentType - The content-type header value to extract charset from
+ * @returns A TextDecoder instance configured with the extracted charset or default decoder
+ */
+export const createTextDecoder = (contentType: string): TextDecoder => {
+	const match = /;\s*charset\s*=\s*(?:"([^"]+)"|([^;,\s]+))/i.exec(contentType);
+	const charset = match?.[1] ?? match?.[2];
+	if (charset) {
+		try {
+			return new TextDecoder(charset);
+		} catch {}
+	}
+
+	return new TextDecoder();
+};
+
 // eslint-disable-next-line @typescript-eslint/no-restricted-types
 export const getBodySize = (body?: BodyInit | null): number => {
 	if (!body) {


### PR DESCRIPTION
## Summary
Extracts the `createTextDecoder` utility function from `Ky.ts` to a dedicated utility module for better code organization and reusability.

Fixes #12

## Changes
- Created `source/utils/body.ts` with `createTextDecoder` function
- Updated `Ky.ts` to import from the new utility module
- Reduced code complexity in the main Ky class

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR performs a straightforward refactoring: `createTextDecoder` is moved from a module-level private constant in `source/core/Ky.ts` into `source/utils/body.ts` as a named export, alongside the existing body-utility functions (`streamRequest`, `streamResponse`, `getBodySize`, etc.). The logic is preserved exactly, and the import in `Ky.ts` is updated correctly. The placement in `body.ts` is coherent because `createTextDecoder` is used to decode response body bytes with the charset from the `Content-Type` header.

**Key changes:**
- `source/utils/body.ts`: `createTextDecoder` added as an exported function with JSDoc documentation.
- `source/core/Ky.ts`: Inline `createTextDecoder` definition removed; `createTextDecoder` added to the existing `body.js` import.

**Minor issue found:**
- Three consecutive blank lines are left in `Ky.ts` where the function used to be; should be reduced to one.
</details>

<h3>Confidence Score: 5/5</h3>

- Safe to merge — pure extraction refactor with no behavioral changes.
- The extracted function is an identical copy of the original, the import is wired up correctly, and `createTextDecoder` is still consumed at the same call-site in `#readResponseText`. The only finding is cosmetic (extra blank lines).
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| source/core/Ky.ts | Removes the inline `createTextDecoder` definition and imports it from `utils/body.ts`; leaves two extra blank lines where the function was removed. |
| source/utils/body.ts | Adds the exported `createTextDecoder` utility with JSDoc; logic is a byte-for-byte copy of the original, so no functional risk. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Ky.ts\n#readResponseText()"] -->|"imports createTextDecoder"| B["utils/body.ts\ncreateTextDecoder(contentType)"]
    B --> C{charset in\nContent-Type?}
    C -->|yes| D["new TextDecoder(charset)"]
    C -->|no / invalid| E["new TextDecoder()\n(UTF-8 default)"]
    D --> F["Decode response\nbody bytes"]
    E --> F
```
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asource%2Fcore%2FKy.ts%3A37-41%0A**Stray%20blank%20lines%20after%20function%20removal**%0A%0AAfter%20removing%20%60createTextDecoder%60%2C%20three%20consecutive%20blank%20lines%20are%20left%20between%20%60prefixUrlRenamedErrorMessage%60%20and%20%60export%20class%20Ky%60.%20The%20convention%20in%20this%20file%20is%20a%20single%20blank%20line%20between%20top-level%20declarations.%0A%0A%60%60%60suggestion%0Aconst%20prefixUrlRenamedErrorMessage%20%3D%20'The%20%60prefixUrl%60%20option%20has%20been%20renamed%20%60prefix%60%20in%20v2%20and%20enhanced%20to%20allow%20slashes%20in%20input.%20See%20also%20the%20new%20%60baseUrl%60%20option%20for%20improved%20flexibility%20with%20standard%20URL%20resolution%3A%20https%3A%2F%2Fgithub.com%2Fsindresorhus%2Fky%23baseurl'%3B%0A%0Aexport%20class%20Ky%20%7B%0A%60%60%60%0A%0A&repo=vikasagarwal101%2Fky"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asource%2Fcore%2FKy.ts%3A37-41%0A**Stray%20blank%20lines%20after%20function%20removal**%0A%0AAfter%20removing%20%60createTextDecoder%60%2C%20three%20consecutive%20blank%20lines%20are%20left%20between%20%60prefixUrlRenamedErrorMessage%60%20and%20%60export%20class%20Ky%60.%20The%20convention%20in%20this%20file%20is%20a%20single%20blank%20line%20between%20top-level%20declarations.%0A%0A%60%60%60suggestion%0Aconst%20prefixUrlRenamedErrorMessage%20%3D%20'The%20%60prefixUrl%60%20option%20has%20been%20renamed%20%60prefix%60%20in%20v2%20and%20enhanced%20to%20allow%20slashes%20in%20input.%20See%20also%20the%20new%20%60baseUrl%60%20option%20for%20improved%20flexibility%20with%20standard%20URL%20resolution%3A%20https%3A%2F%2Fgithub.com%2Fsindresorhus%2Fky%23baseurl'%3B%0A%0Aexport%20class%20Ky%20%7B%0A%60%60%60%0A%0A&repo=vikasagarwal101%2Fky"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<sub>Last reviewed commit: 847b6a7</sub>

<!-- /greptile_comment -->