### PR TITLE
refactor: extract validateJsonWithSchema to utils/schema.ts

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -1,7 +1,6 @@
 import {HTTPError} from '../errors/HTTPError.js';
 import {NonError} from '../errors/NonError.js';
 import {ForceRetryError} from '../errors/ForceRetryError.js';
-import {SchemaValidationError} from '../errors/SchemaValidationError.js';
 import {TimeoutError} from '../errors/TimeoutError.js';
 import type {
 	Input,
@@ -16,6 +15,7 @@ import type {StandardSchemaV1} from '../types/standard-schema.js';
 import {streamRequest, streamResponse} from '../utils/body.js';
 import {mergeHeaders, mergeHooks} from '../utils/merge.js';
 import {normalizeRequestMethod, normalizeRetryOptions} from '../utils/normalize.js';
+import {validateJsonWithSchema} from '../utils/schema.js';
 import timeout, {type TimeoutOptions} from '../utils/timeout.js';
 import delay from '../utils/delay.js';
 import {type ObjectEntries} from '../utils/types.js';
@@ -46,36 +46,6 @@ const createTextDecoder = (contentType: string): TextDecoder => {
 	}
 
 	return new TextDecoder();
-};
-
-const validateJsonWithSchema = async (jsonValue: unknown, schema: StandardSchemaV1): Promise<unknown> => {
-	if (
-		(
-			typeof schema !== 'object'
-			&& typeof schema !== 'function'
-		)
-		|| schema === null
-	) {
-		throw new TypeError('The `schema` argument must follow the Standard Schema specification');
-	}
-
-	const standardSchema = schema['~standard'];
-
-	if (
-		typeof standardSchema !== 'object'
-		|| standardSchema === null
-		|| typeof standardSchema.validate !== 'function'
-	) {
-		throw new TypeError('The `schema` argument must follow the Standard Schema specification');
-	}
-
-	const validationResult = await standardSchema.validate(jsonValue);
-
-	if (validationResult.issues) {
-		throw new SchemaValidationError(validationResult.issues);
-	}
-
-	return validationResult.value;
 };
 
 export class Ky {

--- a/source/utils/schema.ts
+++ b/source/utils/schema.ts
@@ -1,0 +1,41 @@
+import {SchemaValidationError} from '../errors/SchemaValidationError.js';
+import type {StandardSchemaV1} from '../types/standard-schema.js';
+
+/**
+ * Validates a JSON value against a Standard Schema specification.
+ *
+ * @param jsonValue - The JSON value to validate
+ * @param schema - The Standard Schema specification to validate against
+ * @returns The validated value from the schema
+ * @throws {TypeError} If the schema does not follow the Standard Schema specification
+ * @throws {SchemaValidationError} If the validation fails
+ */
+export const validateJsonWithSchema = async (jsonValue: unknown, schema: StandardSchemaV1): Promise<unknown> => {
+	if (
+		(
+			typeof schema !== 'object'
+			&& typeof schema !== 'function'
+		)
+		|| schema === null
+	) {
+		throw new TypeError('The `schema` argument must follow the Standard Schema specification');
+	}
+
+	const standardSchema = schema['~standard'];
+
+	if (
+		typeof standardSchema !== 'object'
+		|| standardSchema === null
+		|| typeof standardSchema.validate !== 'function'
+	) {
+		throw new TypeError('The `schema` argument must follow the Standard Schema specification');
+	}
+
+	const validationResult = await standardSchema.validate(jsonValue);
+
+	if (validationResult.issues) {
+		throw new SchemaValidationError(validationResult.issues);
+	}
+
+	return validationResult.value;
+};


### PR DESCRIPTION
## Summary
Extracts the `validateJsonWithSchema` function from `Ky.ts` to a dedicated schema utility module for better separation of concerns and maintainability.

Fixes #13

## Changes
- Created `source/utils/schema.ts` with `validateJsonWithSchema` function
- Updated `Ky.ts` to import from the new utility module
- Improved code organization by separating schema validation logic

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR is a clean, mechanical refactor that extracts the `validateJsonWithSchema` helper from `source/core/Ky.ts` into a dedicated `source/utils/schema.ts` module. The function's logic is preserved exactly, a JSDoc block is added for documentation, and `Ky.ts` is updated to import from the new utility. The change improves separation of concerns by keeping HTTP-lifecycle code in `Ky.ts` and schema-validation logic in its own utility — consistent with the pattern used by other utilities in `source/utils/`.

- **New file `source/utils/schema.ts`**: exports `validateJsonWithSchema`; imports `SchemaValidationError` and the `StandardSchemaV1` type that were previously pulled into `Ky.ts`.
- **`source/core/Ky.ts`**: drops the inline function and the `SchemaValidationError` import, adds `import {validateJsonWithSchema} from '../utils/schema.js'`. All two call sites (`line 206` and `line 213`) are unchanged.
- No public API surface is affected; `validateJsonWithSchema` remains internal and is not re-exported from `source/index.ts`.
</details>

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a pure refactor with no logic changes and no public API impact.
- The extracted function is byte-for-byte identical to the original; only its location changed. Both call sites in Ky.ts were left untouched, imports resolve correctly, and the module boundary is consistent with the existing `source/utils/` pattern. No behavioral change is introduced.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| source/utils/schema.ts | New utility module extracting `validateJsonWithSchema` from Ky.ts; logic is identical to the original, JSDoc added, imports are correct. |
| source/core/Ky.ts | Removed inline `validateJsonWithSchema` and the `SchemaValidationError` import; replaced with a clean import from the new `../utils/schema.js` utility. All call sites remain unchanged. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Ky.ts
    participant schema.ts
    participant SchemaValidationError

    Caller->>Ky.ts: .json(schema?)
    Ky.ts->>Ky.ts: fetch & parse JSON text
    alt schema provided
        Ky.ts->>schema.ts: validateJsonWithSchema(jsonValue, schema)
        schema.ts->>schema.ts: check schema object shape
        schema.ts->>schema.ts: schema['~standard'].validate(jsonValue)
        alt validation issues
            schema.ts->>SchemaValidationError: throw new SchemaValidationError(issues)
            SchemaValidationError-->>Caller: SchemaValidationError
        else validation passes
            schema.ts-->>Ky.ts: validationResult.value
            Ky.ts-->>Caller: typed response value
        end
    else no schema
        Ky.ts-->>Caller: raw JSON value
    end
```
</details>

<sub>Last reviewed commit: 4b1705c</sub>

<!-- /greptile_comment -->