### PR TITLE
refactor(core): reduce complexity of #calculateRetryDelay method

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -378,42 +378,62 @@ export class Ky {
 		return maxRetryAfter === undefined ? retryDelay : Math.min(maxRetryAfter, retryDelay);
 	}
 
-	async #calculateRetryDelay(error: unknown) {
-		if (this.#retryCount >= this.#options.retry.limit) {
-			throw error;
+	#handleForcedRetry(error: Error): number | undefined {
+		if (error instanceof ForceRetryError) {
+			return error.customDelay ?? this.#calculateDelay();
 		}
 
-		// Wrap non-Error throws to ensure consistent error handling
-		const errorObject = error instanceof Error ? error : new NonError(error);
+		return undefined;
+	}
 
-		// Handle forced retry from afterResponse hook - skip method check and shouldRetry
-		if (errorObject instanceof ForceRetryError) {
-			return errorObject.customDelay ?? this.#calculateDelay();
+	#isMethodRetriable(): boolean {
+		return this.#options.retry.methods.includes(this.request.method.toLowerCase());
+	}
+
+	async #handleShouldRetry(errorObject: Error, originalError: unknown): Promise<number | undefined> {
+		if (this.#options.retry.shouldRetry === undefined) {
+			return undefined;
 		}
 
-		// Check if method is retriable for non-forced retries
-		if (!this.#options.retry.methods.includes(this.request.method.toLowerCase())) {
-			throw error;
+		const result = await this.#options.retry.shouldRetry({error: errorObject, retryCount: this.#retryCount + 1});
+
+		if (result === false) {
+			throw originalError;
 		}
 
-		// User-provided shouldRetry function takes precedence over default checks (retryOnTimeout, status codes, etc.)
-		if (this.#options.retry.shouldRetry !== undefined) {
-			const result = await this.#options.retry.shouldRetry({error: errorObject, retryCount: this.#retryCount + 1});
-
-			// Strict boolean checking - only exact true/false are handled specially
-			if (result === false) {
-				throw error;
-			}
-
-			if (result === true) {
-				// Force retry - skip all other validation and return delay
-				return this.#calculateDelay();
-			}
-
-			// If undefined or any other value, fall through to default behavior
+		if (result === true) {
+			return this.#calculateDelay();
 		}
 
-		// Default timeout behavior
+		return undefined;
+	}
+
+	#getRetryAfterDelay(error: HTTPError): number | undefined {
+		const retryAfter = error.response.headers.get('Retry-After')
+			?? error.response.headers.get('RateLimit-Reset')
+			?? error.response.headers.get('X-RateLimit-Retry-After') // Symfony-based services
+			?? error.response.headers.get('X-RateLimit-Reset') // GitHub
+			?? error.response.headers.get('X-Rate-Limit-Reset'); // Twitter
+
+		if (!retryAfter || !this.#options.retry.afterStatusCodes.includes(error.response.status)) {
+			return undefined;
+		}
+
+		let after = Number(retryAfter) * 1000;
+		if (Number.isNaN(after)) {
+			after = Date.parse(retryAfter) - Date.now();
+		} else if (after >= Date.parse('2024-01-01')) {
+			after -= Date.now();
+		}
+
+		if (!Number.isFinite(after)) {
+			return this.#clampRetryDelayToMax(this.#calculateDelay());
+		}
+
+		return this.#clampRetryDelayToMax(Math.max(0, after));
+	}
+
+	#handleTimeoutAndDefaultRetry(error: unknown): number {
 		if (isTimeoutError(error) && !this.#options.retry.retryOnTimeout) {
 			throw error;
 		}
@@ -423,28 +443,9 @@ export class Ky {
 				throw error;
 			}
 
-			const retryAfter = error.response.headers.get('Retry-After')
-				?? error.response.headers.get('RateLimit-Reset')
-				?? error.response.headers.get('X-RateLimit-Retry-After') // Symfony-based services
-				?? error.response.headers.get('X-RateLimit-Reset') // GitHub
-				?? error.response.headers.get('X-Rate-Limit-Reset'); // Twitter
-			if (retryAfter && this.#options.retry.afterStatusCodes.includes(error.response.status)) {
-				let after = Number(retryAfter) * 1000;
-				if (Number.isNaN(after)) {
-					after = Date.parse(retryAfter) - Date.now();
-				} else if (after >= Date.parse('2024-01-01')) {
-					// A large number is treated as a timestamp (fixed threshold protects against clock skew)
-					after -= Date.now();
-				}
-
-				if (!Number.isFinite(after)) {
-					return this.#clampRetryDelayToMax(this.#calculateDelay());
-				}
-
-				after = Math.max(0, after);
-
-				// Don't apply jitter when server provides explicit retry timing
-				return this.#clampRetryDelayToMax(after);
+			const retryAfterDelay = this.#getRetryAfterDelay(error);
+			if (retryAfterDelay !== undefined) {
+				return retryAfterDelay;
 			}
 
 			if (error.response.status === 413) {
@@ -453,6 +454,30 @@ export class Ky {
 		}
 
 		return this.#calculateDelay();
+	}
+
+	async #calculateRetryDelay(error: unknown) {
+		if (this.#retryCount >= this.#options.retry.limit) {
+			throw error;
+		}
+
+		const errorObject = error instanceof Error ? error : new NonError(error);
+
+		const forcedRetryDelay = this.#handleForcedRetry(errorObject);
+		if (forcedRetryDelay !== undefined) {
+			return forcedRetryDelay;
+		}
+
+		if (!this.#isMethodRetriable()) {
+			throw error;
+		}
+
+		const shouldRetryDelay = await this.#handleShouldRetry(errorObject, error);
+		if (shouldRetryDelay !== undefined) {
+			return shouldRetryDelay;
+		}
+
+		return this.#handleTimeoutAndDefaultRetry(error);
 	}
 
 	#decorateResponse(response: Response): Response {


### PR DESCRIPTION
## Summary

Reduces the complexity of the private async method `#calculateRetryDelay` in `source/core/Ky.ts` from 23 to within the allowed maximum of 20.

Fixes #18

## Changes
- Extracted helper methods to reduce branching:
  - Forced retry handling
  - Method retriable check
  - ShouldRetry logic
  - Timeout/default retry logic

## Testing
- All existing tests pass
- No functional changes - pure refactoring

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR reduces the cyclomatic complexity of the private `#calculateRetryDelay` method in `source/core/Ky.ts` by extracting five focused helper methods, bringing it within the allowed maximum of 20. The refactoring is purely structural — no functional behavior changes — and the overall control flow is preserved exactly.

**Key changes:**
- `#handleForcedRetry` — short-circuits for `ForceRetryError`, skipping method and `shouldRetry` checks
- `#isMethodRetriable` — extracts the HTTP-method allowlist check
- `#handleShouldRetry` — delegates to the user-supplied `shouldRetry` callback and interprets its result
- `#getRetryAfterDelay` — isolates `Retry-After` / rate-limit header parsing and clamping
- `#handleTimeoutAndDefaultRetry` — consolidates the timeout guard, HTTP status checks, and fallback delay

**Issues flagged:**
- `#handleShouldRetry` has mixed concerns: it returns a computed delay **and** throws the original error on `result === false`. This hidden throw side-effect makes the method harder to reason about in isolation; consider renaming or adding explicit JSDoc.
- The explanatory comment about the `'2024-01-01'` threshold in `#getRetryAfterDelay` was not preserved during extraction. This magic constant is non-obvious and the comment is important for future maintainability.
</details>

<h3>Confidence Score: 4/5</h3>

- Safe to merge — pure structural refactoring with no functional changes; only minor documentation and code clarity concerns flagged.
- The refactoring is a faithful decomposition of the original method: all branching conditions, throw paths, and return values are preserved in the correct order. The two flagged items are style and documentation concerns (a missing explanatory comment and mixed return/throw behavior in a helper), not logic bugs. Existing tests should provide sufficient coverage since no behavior changed. Both issues are addressable without affecting the safe nature of this change.
- source/core/Ky.ts — address the two style/documentation concerns around `#handleShouldRetry` and the missing comment in `#getRetryAfterDelay`.

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["#calculateRetryDelay(error)"] --> B{retryCount >= limit?}
    B -- Yes --> C[throw error]
    B -- No --> D["wrap as errorObject (NonError if needed)"]
    D --> E["#handleForcedRetry(errorObject)"]
    E -- "ForceRetryError → returns delay" --> F[return forcedRetryDelay]
    E -- "not ForceRetryError → undefined" --> G["#isMethodRetriable()"]
    G -- false --> H[throw error]
    G -- true --> I["#handleShouldRetry(errorObject, error)"]
    I -- "shouldRetry undefined → undefined" --> J["#handleTimeoutAndDefaultRetry(error)"]
    I -- "result === false → throws" --> K[throw originalError]
    I -- "result === true → returns delay" --> L[return shouldRetryDelay]
    I -- "other result → undefined" --> J
    J -- "timeout && !retryOnTimeout" --> M[throw error]
    J -- "HTTPError, status not in list" --> N[throw error]
    J -- "HTTPError, Retry-After header present" --> O["#getRetryAfterDelay(error)"]
    O --> P[return clamped Retry-After delay]
    J -- "status === 413" --> Q[throw error]
    J -- "default" --> R["return #calculateDelay()"]
```
</details>

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asource%2Fcore%2FKy.ts%3A393-409%0A%60%23handleShouldRetry%60%20mixes%20two%20distinct%20responsibilities%3A%20it%20returns%20a%20computed%20delay%20value%20**and**%20throws%20the%20original%20error%20when%20%60result%20%3D%3D%3D%20false%60.%20The%20throw%20at%20line%20401%20is%20a%20hidden%20side-effect%20that%20is%20not%20obvious%20from%20the%20method%20signature%20or%20name.%0A%0AA%20caller%20reading%20%60const%20shouldRetryDelay%20%3D%20await%20this.%23handleShouldRetry%28...%29%60%20expects%20a%20query-like%20helper%3B%20the%20throw%20is%20surprising.%20Consider%20renaming%20to%20something%20like%20%60%23evaluateShouldRetry%60%20or%20adding%20explicit%20JSDoc%20documenting%20the%20throw%20path%3A%0A%0A%60%60%60suggestion%0A%09%2F**%0A%09%20*%20Evaluates%20the%20shouldRetry%20callback%20and%20handles%20the%20result.%0A%09%20*%20%40throws%20%7Bunknown%7D%20Throws%20the%20original%20error%20if%20shouldRetry%20returns%20false.%0A%09%20*%20%40returns%20The%20retry%20delay%20if%20shouldRetry%20returns%20true%2C%20undefined%20if%20returns%20false%20or%20if%20shouldRetry%20is%20not%20defined.%0A%09%20*%2F%0A%09async%20%23handleShouldRetry%28errorObject%3A%20Error%2C%20originalError%3A%20unknown%29%3A%20Promise%3Cnumber%20%7C%20undefined%3E%20%7B%0A%09%09if%20%28this.%23options.retry.shouldRetry%20%3D%3D%3D%20undefined%29%20%7B%0A%09%09%09return%20undefined%3B%0A%09%09%7D%0A%0A%09%09const%20result%20%3D%20await%20this.%23options.retry.shouldRetry%28%7Berror%3A%20errorObject%2C%20retryCount%3A%20this.%23retryCount%20%2B%201%7D%29%3B%0A%0A%09%09if%20%28result%20%3D%3D%3D%20false%29%20%7B%0A%09%09%09throw%20originalError%3B%0A%09%09%7D%0A%0A%09%09if%20%28result%20%3D%3D%3D%20true%29%20%7B%0A%09%09%09return%20this.%23calculateDelay%28%29%3B%0A%09%09%7D%0A%0A%09%09return%20undefined%3B%0A%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asource%2Fcore%2FKy.ts%3A425-427%0AThe%20explanatory%20comment%20about%20the%20%60'2024-01-01'%60%20threshold%20was%20lost%20during%20refactoring.%20This%20magic%20constant%20is%20non-obvious%20%E2%80%94%20it%20distinguishes%20between%20a%20seconds-based%20delay%20and%20a%20Unix%20timestamp%20using%20a%20fixed%20cutoff%20date%20to%20protect%20against%20clock%20skew.%20Without%20the%20comment%2C%20future%20maintainers%20may%20not%20understand%20why%20this%20hardcoded%20date%20is%20appropriate%20here.%0A%0A%60%60%60suggestion%0A%09%09%7D%20else%20if%20%28after%20%3E%3D%20Date.parse%28'2024-01-01'%29%29%20%7B%0A%09%09%09%2F%2F%20A%20large%20number%20is%20treated%20as%20a%20Unix%20timestamp%20%28fixed%20threshold%20protects%20against%20clock%20skew%29%0A%09%09%09after%20-%3D%20Date.now%28%29%3B%0A%60%60%60%0A%0A&repo=vikasagarwal101%2Fky"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asource%2Fcore%2FKy.ts%3A393-409%0A%60%23handleShouldRetry%60%20mixes%20two%20distinct%20responsibilities%3A%20it%20returns%20a%20computed%20delay%20value%20**and**%20throws%20the%20original%20error%20when%20%60result%20%3D%3D%3D%20false%60.%20The%20throw%20at%20line%20401%20is%20a%20hidden%20side-effect%20that%20is%20not%20obvious%20from%20the%20method%20signature%20or%20name.%0A%0AA%20caller%20reading%20%60const%20shouldRetryDelay%20%3D%20await%20this.%23handleShouldRetry%28...%29%60%20expects%20a%20query-like%20helper%3B%20the%20throw%20is%20surprising.%20Consider%20renaming%20to%20something%20like%20%60%23evaluateShouldRetry%60%20or%20adding%20explicit%20JSDoc%20documenting%20the%20throw%20path%3A%0A%0A%60%60%60suggestion%0A%09%2F**%0A%09%20*%20Evaluates%20the%20shouldRetry%20callback%20and%20handles%20the%20result.%0A%09%20*%20%40throws%20%7Bunknown%7D%20Throws%20the%20original%20error%20if%20shouldRetry%20returns%20false.%0A%09%20*%20%40returns%20The%20retry%20delay%20if%20shouldRetry%20returns%20true%2C%20undefined%20if%20returns%20false%20or%20if%20shouldRetry%20is%20not%20defined.%0A%09%20*%2F%0A%09async%20%23handleShouldRetry%28errorObject%3A%20Error%2C%20originalError%3A%20unknown%29%3A%20Promise%3Cnumber%20%7C%20undefined%3E%20%7B%0A%09%09if%20%28this.%23options.retry.shouldRetry%20%3D%3D%3D%20undefined%29%20%7B%0A%09%09%09return%20undefined%3B%0A%09%09%7D%0A%0A%09%09const%20result%20%3D%20await%20this.%23options.retry.shouldRetry%28%7Berror%3A%20errorObject%2C%20retryCount%3A%20this.%23retryCount%20%2B%201%7D%29%3B%0A%0A%09%09if%20%28result%20%3D%3D%3D%20false%29%20%7B%0A%09%09%09throw%20originalError%3B%0A%09%09%7D%0A%0A%09%09if%20%28result%20%3D%3D%3D%20true%29%20%7B%0A%09%09%09return%20this.%23calculateDelay%28%29%3B%0A%09%09%7D%0A%0A%09%09return%20undefined%3B%0A%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asource%2Fcore%2FKy.ts%3A425-427%0AThe%20explanatory%20comment%20about%20the%20%60'2024-01-01'%60%20threshold%20was%20lost%20during%20refactoring.%20This%20magic%20constant%20is%20non-obvious%20%E2%80%94%20it%20distinguishes%20between%20a%20seconds-based%20delay%20and%20a%20Unix%20timestamp%20using%20a%20fixed%20cutoff%20date%20to%20protect%20against%20clock%20skew.%20Without%20the%20comment%2C%20future%20maintainers%20may%20not%20understand%20why%20this%20hardcoded%20date%20is%20appropriate%20here.%0A%0A%60%60%60suggestion%0A%09%09%7D%20else%20if%20%28after%20%3E%3D%20Date.parse%28'2024-01-01'%29%29%20%7B%0A%09%09%09%2F%2F%20A%20large%20number%20is%20treated%20as%20a%20Unix%20timestamp%20%28fixed%20threshold%20protects%20against%20clock%20skew%29%0A%09%09%09after%20-%3D%20Date.now%28%29%3B%0A%60%60%60%0A%0A&repo=vikasagarwal101%2Fky"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<sub>Last reviewed commit: 9affc59</sub>

<!-- /greptile_comment -->