### PR TITLE
fix(lint): resolve no-promise-executor-return errors in test/retry/hooks.ts

### DIFF
--- a/test/retry/hooks.ts
+++ b/test/retry/hooks.ts
@@ -11,7 +11,7 @@ test('shouldRetry: returns true cannot exceed total timeout budget', async t => 
 	server.get('/', async (_request, response) => {
 		requestCount++;
 		// Delay longer than timeout to trigger timeout
-		await new Promise(resolve => setTimeout(resolve, 1000));
+		await new Promise(resolve => { setTimeout(resolve, 1000); });
 		response.end(fixture);
 	});
 
@@ -181,7 +181,7 @@ test('shouldRetry: works with TimeoutError', async t => {
 	server.get('/', async (_request, response) => {
 		requestCount++;
 		// Delay longer than timeout to trigger timeout
-		await new Promise(resolve => setTimeout(resolve, 1000));
+		await new Promise(resolve => { setTimeout(resolve, 1000); });
 		response.end(fixture);
 	});
 
@@ -212,7 +212,7 @@ test('shouldRetry: precedence over retryOnTimeout', async t => {
 	server.get('/', async (_request, response) => {
 		requestCount++;
 		// Delay longer than timeout to trigger timeout
-		await new Promise(resolve => setTimeout(resolve, 1000));
+		await new Promise(resolve => { setTimeout(resolve, 1000); });
 		response.end(fixture);
 	});
 


### PR DESCRIPTION
## Summary

Fixes 3 `no-promise-executor-return` lint errors in test/retry/hooks.ts by wrapping setTimeout calls in braces to avoid implicit return.

Fixes #30

## Changes
- Wrapped setTimeout calls in Promise executor with braces at lines 14, 184, and 215
- Changed from: `await new Promise(resolve => setTimeout(resolve, 1000));`
- Changed to: `await new Promise(resolve => { setTimeout(resolve, 1000); });`

## Testing
- Lint errors should be resolved
- Tests should pass

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes three ESLint `no-promise-executor-return` violations in `test/retry/hooks.ts` by converting implicit-return arrow functions (`resolve => setTimeout(resolve, 1000)`) into block-body arrow functions (`resolve => { setTimeout(resolve, 1000); }`). The change is purely cosmetic with respect to runtime behavior — `setTimeout` is still called identically and `resolve` is still invoked after 1000 ms — but it correctly prevents the `NodeJS.Timeout` handle from being implicitly returned from the Promise executor.

- Affects only the test file; no production source code is changed.
- All three modified lines (14, 184, 215) are identical in pattern and the fix is applied consistently.
- No new logic, imports, or test cases are introduced.
</details>

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a pure lint fix with no behavioral changes.
- All three changes are mechanically equivalent to the original code at runtime; only the arrow function syntax is altered to satisfy the `no-promise-executor-return` rule. No production code, logic, or test assertions are affected.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| test/retry/hooks.ts | Three `no-promise-executor-return` lint errors fixed by wrapping `setTimeout` calls in block bodies; behavior is functionally identical and the changes are correct. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test as Ava Test
    participant Ky as ky HTTP client
    participant Server as Test HTTP Server

    Test->>Ky: ky(url, timeout 500ms, retry limit 3)
    Ky->>Server: GET /
    Note over Server: Server delays 1000ms via setTimeout
    Note over Ky: Client timeout fires at 500ms
    Ky-->>Test: throws TimeoutError
    Test->>Test: t.throwsAsync resolves
```
</details>

<sub>Last reviewed commit: ecf2649</sub>

<!-- /greptile_comment -->