### PR TITLE
fix(test): resolve critical errors in split test hook files

### DIFF
--- a/source/core/Ky.ts
+++ b/source/core/Ky.ts
@@ -36,8 +36,6 @@ import {
 const maxErrorResponseBodySize = 10 * 1024 * 1024;
 const prefixUrlRenamedErrorMessage = 'The `prefixUrl` option has been renamed `prefix` in v2 and enhanced to allow slashes in input. See also the new `baseUrl` option for improved flexibility with standard URL resolution: https://github.com/sindresorhus/ky#baseurl';
 
-
-
 export class Ky {
 	static create(input: Input, options: Options): ResponsePromise {
 		const ky = new Ky(input, options);

--- a/test/retry/hooks.ts
+++ b/test/retry/hooks.ts
@@ -11,7 +11,9 @@ test('shouldRetry: returns true cannot exceed total timeout budget', async t => 
 	server.get('/', async (_request, response) => {
 		requestCount++;
 		// Delay longer than timeout to trigger timeout
-		await new Promise(resolve => setTimeout(resolve, 1000));
+		await new Promise(resolve => {
+			void setTimeout(resolve, 1000);
+		});
 		response.end(fixture);
 	});
 
@@ -181,7 +183,9 @@ test('shouldRetry: works with TimeoutError', async t => {
 	server.get('/', async (_request, response) => {
 		requestCount++;
 		// Delay longer than timeout to trigger timeout
-		await new Promise(resolve => setTimeout(resolve, 1000));
+		await new Promise(resolve => {
+			void setTimeout(resolve, 1000);
+		});
 		response.end(fixture);
 	});
 
@@ -212,7 +216,9 @@ test('shouldRetry: precedence over retryOnTimeout', async t => {
 	server.get('/', async (_request, response) => {
 		requestCount++;
 		// Delay longer than timeout to trigger timeout
-		await new Promise(resolve => setTimeout(resolve, 1000));
+		await new Promise(resolve => {
+			void setTimeout(resolve, 1000);
+		});
 		response.end(fixture);
 	});
 


### PR DESCRIPTION
## Summary

Fixes #27

This PR resolves lint errors that were blocking the test suite:

### Changes Made

1. **test/retry/hooks.ts** - Fixed promise executor return issues
   - Added `void` before `setTimeout(resolve, 1000)` calls on lines 15, 187, and 220
   - This resolves the `no-promise-executor-return` linter errors

2. **source/core/Ky.ts** - Fixed multiple blank lines issue
   - Removed extra blank lines before the `export class Ky` declaration
   - This resolves the `@stylistic/no-multiple-empty-lines` linter error

### Testing

- `npm test` now passes the linting phase (xo)
- Build (tsc) succeeds
- Some tests may fail due to Playwright dependencies not being installed in the environment (unrelated to this fix)

### Merge Readiness Score: 4/5

The code changes are complete and correct. The only reason for not being 5/5 is that some browser tests may require Playwright dependencies to be installed, but that is an environment issue, not a code issue.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes two small lint-only fixes to unblock `npm test`:

- **`test/retry/hooks.ts`** – Three concise arrow-function promise executors (`resolve => setTimeout(resolve, 1000)`) are rewritten as block bodies with `void` to satisfy the `no-promise-executor-return` ESLint rule. The behaviour is identical: `setTimeout` is still called with `resolve` as the callback and the returned timer ID is intentionally discarded.
- **`source/core/Ky.ts`** – Two consecutive blank lines before `export class Ky` are removed to satisfy `@stylistic/no-multiple-empty-lines`.

Both changes are minimal, non-functional, and correct. No logic was altered.
</details>

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — all changes are lint-only fixes with no functional impact.
- Both changes are purely cosmetic/linting: removing extra blank lines and wrapping `setTimeout` calls in `void` to suppress ESLint warnings. No logic, APIs, or interfaces were modified, so there is no regression risk.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| test/retry/hooks.ts | Three identical promise-executor fixes: concise arrow-function bodies returning a `setTimeout` timer ID are replaced with block bodies using `void` to satisfy the `no-promise-executor-return` linter rule. Semantically equivalent and correct. |
| source/core/Ky.ts | Two extra blank lines before `export class Ky` are removed to satisfy the `@stylistic/no-multiple-empty-lines` linter rule. Purely cosmetic, no functional change. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test as AVA Test
    participant Server as HTTP Test Server
    participant Ky as ky client

    Test->>Server: GET /
    Note over Server: void setTimeout(resolve, 1000) delays 1s
    Server-->>Ky: response after 1s
    Note over Ky: timeout=500ms fires first
    Ky-->>Test: throws TimeoutError
    Test->>Test: t.throwsAsync assertion passes
```
</details>

<sub>Last reviewed commit: 0e3ef6a</sub>

<!-- /greptile_comment -->